### PR TITLE
add lintOptions.isCheckGeneratedSources for rur.lint.onlyUnusedResources

### DIFF
--- a/README.md
+++ b/README.md
@@ -127,6 +127,7 @@ lintOptions {
   // These settings are applied automatically by the plugin, when -Prur.lint.onlyUnusedResources is specified,
   // so you don't have to add these settings in build.gradle.kts.
   xmlReport = true
+  isCheckGeneratedSources = true
   isCheckDependencies = true
   checkOnly.clear()
   checkOnly("UnusedResources")

--- a/plugin/src/main/kotlin/io/github/irgaly/gradle/rur/RemoveUnusedResourcesPlugin.kt
+++ b/plugin/src/main/kotlin/io/github/irgaly/gradle/rur/RemoveUnusedResourcesPlugin.kt
@@ -41,6 +41,7 @@ class RemoveUnusedResourcesPlugin : Plugin<Project> {
                         if (onlyUnusedResources) {
                             if (project == target) {
                                 xmlReport = true
+                                isCheckGeneratedSources = true
                                 isCheckDependencies = true
                             }
                             checkOnly.clear()


### PR DESCRIPTION

isCheckGeneratedSources is always needed for UnusedResources checks.
so add isCheckGeneratedSources = true to onlyUnusedResources option.