### PR TITLE
Renovate: ignore plugin myself

### DIFF
--- a/renovate.json
+++ b/renovate.json
@@ -10,6 +10,12 @@
         "patch"
       ],
       "enabled": false
+    },
+    {
+      "matchPackageNames": [
+        "io.github.irgaly.remove-unused-resources:io.github.irgaly.remove-unused-resources.gradle.plugin"
+      ],
+      "enabled": false
     }
   ]
 }


### PR DESCRIPTION
`io.github.irgaly.remove-unused-resources:io.github.irgaly.remove-unused-resources.gradle.plugin` が unspecified で検出されているため除外する。