### PR TITLE
CI: fix diff comment, multiline

### DIFF
--- a/.github/workflows/test_diff.yml
+++ b/.github/workflows/test_diff.yml
@@ -25,7 +25,11 @@ jobs:
         run: |
           git diff --unified=0 | sed "/^index .*$/d" > sample.diff.new
           diff -u sample.diff sample.diff.new > sample.diff.changes || (
-            echo "diff=$(cat sample.diff.changes | tail -n +3 | sed -z 's/\n/%0A/g')" >> $GITHUB_OUTPUT
+            {
+              echo "diff<<EOF"
+              cat sample.diff.changes | tail -n +3
+              echo "EOF"
+            } >> "$GITHUB_OUTPUT"
             exit 1
           )
       - uses: peter-evans/find-comment@v3


### PR DESCRIPTION
using `%0A` escaping is no more worked for GITHUB_OUTPUT.

* https://docs.github.com/en/actions/reference/workflow-commands-for-github-actions#multiline-strings
* related: https://github.com/actions/upload-artifact/issues/394